### PR TITLE
response messages don't need a source field

### DIFF
--- a/docs/agent-bridging/spec.md
+++ b/docs/agent-bridging/spec.md
@@ -526,7 +526,7 @@ Request messages forwarded by the Bridge onto other Desktop Agents use the same 
 Response messages from a Desktop Agent back to the Bridge use a similar format that is differentiated from requests by the presence of a `meta.responseUuid` field. They MUST also quote the `meta.requestUuid` that they are responding to.
 
 :::info
-Response messages do not include a `meta.destination` as the routing of responses is handled by the Bridge via the `meta.requestUuid` field.
+Response messages do not include a `meta.destination` as the routing of responses is handled by the Bridge via the `meta.requestUuid` field. They also do not include a `source` field as responses are currently always from the Desktop Agent, and the bridge is required to provide this information itself to prevent spoofing.
 :::
 
 There are two types of each response message, a successful response and an error response.
@@ -572,10 +572,7 @@ There are two types of each response message, a successful response and an error
         /** UUID for this specific response message. */
         responseUuid:  string,
         /** Timestamp at which request was generated */
-        timestamp:  Date,
-        /** AppIdentifiers or DesktopAgentIdentifiers for the source
-         *  that generated the response to the request. */
-        source?: (AppIdentifier | DesktopAgentIdentifier),
+        timestamp:  Date
     }
 }
 ```
@@ -602,10 +599,7 @@ There are two types of each response message, a successful response and an error
         /** UUID for this specific response message. */
         responseUuid:  string,
         /** Timestamp at which request was generated */
-        timestamp:  Date,
-        /** AppIdentifiers or DesktopAgentIdentifiers for the source
-         *  that generated the response to the request. */
-        source?: (AppIdentifier | DesktopAgentIdentifier),
+        timestamp:  Date
     }
 }
 ```
@@ -614,9 +608,9 @@ There are two types of each response message, a successful response and an error
 
 ##### Response Messages Collated and Forwarded by the Bridge
 
-Responses from individual Desktop Agents are collated by the Bridge and are forwarded on to the the Desktop Agent that initiated the interaction. The format used is very similar to that used for responses by the Desktop Agents, with the exception of the source information in the `meta` field. Specifically, the `meta.source` field is replaced by two arrays, `meta.sources` and `meta.errorSources`, which provide details on the Desktop agents that responded normally or responded with errors. The detail of any errors returned (in the `payload.error` field of a Desktop Agent's response) is collected up into a `meta.errorDetails` field. Moving the error details from the `payload` to the `meta` field enables the return of a valid response to the originating Desktop Agent in cases where some agents produced valid responses, and others produced errors.
+Responses from individual Desktop Agents are collated by the Bridge and are forwarded on to the the Desktop Agent that initiated the interaction. The format used is very similar to that used for responses by the Desktop Agents, with the exception of the source information in the `meta` field. Specifically, the `meta.source` field does not need to be provided by agents, as responses are currently always provided by the desktop agent, whose details will be provided by the  bridge when it receives the response. In responses from the bridge, the `meta.source` is replaced by two arrays, `meta.sources` and `meta.errorSources`, which provide details on the Desktop agents that responded normally or responded with errors. The detail of any errors returned (in the `payload.error` field of a Desktop Agent's response) is collected up into a `meta.errorDetails` field. Moving the error details from the `payload` to the `meta` field enables the return of a valid response to the originating Desktop Agent in cases where some agents produced valid responses, and others produced errors.
 
-Hence, for responses forwarded by the bridge there is only a single type of response messages from the Bridge returned to agents, one for requests that received at least one successful response, and another for use when all agents (or the targeted agent) returned an error.
+Hence, for responses forwarded by the bridge there are two type of response messages from the Bridge returned to agents, one for requests that received at least one successful response, and another for use when all agents (or the targeted agent) returned an error.
 
 ##### At Least One Successful Response
 
@@ -799,7 +793,7 @@ For example, a `raiseIntent` targeted at an app instance that no longer exists m
 }
 ```
 
-For messages that target a specific agent, the Desktop Agent Bridge will augment the message with a `source` field and return it to the calling agent and the app that made the original request.
+For messages that target a specific agent, the Desktop Agent Bridge will augment the message with source information and return it to the calling agent, which will then respond to the app that made the original request.
 
 If all agents (or the targeted agent) return errors, then a suitable error string should be forwarded in the `payload.error` field as returned by at least one of the agents. This allows the agent that made the original request to return that error to the app that made the original API call. All agents that returned errors should be listed in the `errorSources` array and the error message strings they returned (or that were applied because they timed out) listed in the `errorDetails` array (in the same order as `errorSources`).
 

--- a/schemas/bridging/agentResponse.schema.json
+++ b/schemas/bridging/agentResponse.schema.json
@@ -44,14 +44,9 @@
         },
         "timestamp": {
           "$ref": "common.schema.json#/$defs/Timestamp"
-        },
-        "source": {
-          "title": "Response Source identifier",
-          "description": "Field that represents the source application instance that the response was produced by, or the Desktop Agent if it produced the response without an application.",
-          "$ref": "common.schema.json#/$defs/ResponseSource"
         }
       },
-      "required": ["requestUuid", "responseUuid", "timestamp", "source"],
+      "required": ["requestUuid", "responseUuid", "timestamp"],
       "additionalProperties": false
     }
   }

--- a/schemas/bridging/common.schema.json
+++ b/schemas/bridging/common.schema.json
@@ -54,11 +54,6 @@
         }
       ]
     },
-    "ResponseSource": {
-      "title": "Source identifier",
-      "description": "Field that represents the source Desktop Agent that a response was received from.",
-      "$ref": "../api/api.schema.json#/definitions/DesktopAgentIdentifier"
-    },
     "BridgeRequestSource": {
       "title": "Bridge Source identifier",
       "description": "Field that represents the source application that a request or response was received from, or the source Desktop Agent if it issued the request or response itself.",

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -146,42 +146,7 @@ export interface AgentErrorResponseMessage {
 export interface AgentResponseMetadata {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
-}
-
-/**
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
- *
- * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
- * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
- * response message is returned by the Desktop Agent (or more specifically its resolver)
- * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
- * app details are available or are appropriate.
- *
- * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
- * before the timeout or because an error occurred. May be omitted if all sources responded
- * without errors. MUST include the `desktopAgent` field when returned by the bridge.
- *
- * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
- * Will contain a single value for individual responses and multiple values for responses
- * that were collated by the bridge. May be omitted if all sources errored. MUST include the
- * `desktopAgent` field when returned by the bridge.
- */
-export interface DesktopAgentIdentifier {
-  /**
-   * Used in Desktop Agent Bridging to attribute or target a message to a
-   * particular Desktop Agent.
-   */
-  desktopAgent: string;
-  [property: string]: any;
 }
 
 /**
@@ -304,11 +269,6 @@ export interface AgentRequestMetadata {
  * `source.instanceId` MUST be set, indicating the specific app instance that
  * received the intent.
  *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
- *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
  * response message is returned by the Desktop Agent (or more specifically its resolver)
@@ -365,11 +325,6 @@ export interface BridgeParticipantIdentifier {
  * Identifier for the app instance that was selected (or started) to resolve the intent.
  * `source.instanceId` MUST be set, indicating the specific app instance that
  * received the intent.
- *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
  *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
@@ -474,6 +429,31 @@ export interface BridgeErrorResponseMessageMeta {
 }
 
 /**
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ */
+export interface DesktopAgentIdentifier {
+  /**
+   * Used in Desktop Agent Bridging to attribute or target a message to a
+   * particular Desktop Agent.
+   */
+  desktopAgent: string;
+  [property: string]: any;
+}
+
+/**
  * The error message payload contains details of an error return to the app or agent that
  * raised the original request.
  */
@@ -523,11 +503,6 @@ export interface BridgeRequestMetadata {
  *
  * Field that represents the source application that a request or response was received
  * from, or the source Desktop Agent if it issued the request or response itself.
- *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
  *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
@@ -659,11 +634,6 @@ export interface BroadcastAgentRequestMeta {
  * Field that represents the source application that a request or response was received
  * from, or the source Desktop Agent if it issued the request or response itself.
  *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
- *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
  * response message is returned by the Desktop Agent (or more specifically its resolver)
@@ -775,11 +745,6 @@ export interface BroadcastBridgeRequestMeta {
  *
  * Field that represents the source application that a request or response was received
  * from, or the source Desktop Agent if it issued the request or response itself.
- *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
  *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
@@ -1125,11 +1090,6 @@ export interface FindInstancesAgentErrorResponse {
 export interface FindInstancesAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -1206,11 +1166,6 @@ export interface FindInstancesAgentRequestMeta {
 }
 
 /**
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
- *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
  * response message is returned by the Desktop Agent (or more specifically its resolver)
@@ -1338,11 +1293,6 @@ export interface FindInstancesAgentResponse {
 export interface FindInstancesAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -1616,11 +1566,6 @@ export interface FindIntentAgentErrorResponse {
 export interface FindIntentAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -1700,11 +1645,6 @@ export interface FindIntentAgentResponse {
 export interface FindIntentAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -1892,11 +1832,6 @@ export interface FindIntentsByContextAgentErrorResponse {
 export interface FindIntentsByContextAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -1976,11 +1911,6 @@ export interface FindIntentsByContextAgentResponse {
 export interface FindIntentsByContextAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -2138,11 +2068,6 @@ export interface GetAppMetadataAgentErrorResponse {
 export interface GetAppMetadataAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -2221,11 +2146,6 @@ export interface GetAppMetadataAgentResponse {
 export interface GetAppMetadataAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -2382,11 +2302,6 @@ export interface OpenAgentErrorResponse {
 export interface OpenAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -2473,11 +2388,6 @@ export interface OpenAgentRequestPayload {
 /**
  * The application to open on the specified Desktop Agent
  *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
- *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
  * response message is returned by the Desktop Agent (or more specifically its resolver)
@@ -2552,11 +2462,6 @@ export interface OpenAgentResponse {
 export interface OpenAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -2755,11 +2660,6 @@ export interface PrivateChannelBroadcastAgentRequestMeta {
  *
  * Field that represents the source application that a request or response was received
  * from, or the source Desktop Agent if it issued the request or response itself.
- *
- * Field that represents the source application instance that the response was produced by,
- * or the Desktop Agent if it produced the response without an application.
- *
- * Field that represents the source Desktop Agent that a response was received from.
  *
  * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
  * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
@@ -3336,11 +3236,6 @@ export interface RaiseIntentAgentErrorResponse {
 export interface RaiseIntentAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -3421,11 +3316,6 @@ export interface RaiseIntentAgentResponse {
 export interface RaiseIntentAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -3629,11 +3519,6 @@ export interface RaiseIntentResultAgentErrorResponse {
 export interface RaiseIntentResultAgentErrorResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -3689,11 +3574,6 @@ export interface RaiseIntentResultAgentResponse {
 export interface RaiseIntentResultAgentResponseMeta {
   requestUuid: string;
   responseUuid: string;
-  /**
-   * Field that represents the source application instance that the response was produced by,
-   * or the Desktop Agent if it produced the response without an application.
-   */
-  source: DesktopAgentIdentifier;
   timestamp: Date;
 }
 
@@ -4641,12 +4521,10 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
   ),
-  DesktopAgentIdentifier: o([{ json: 'desktopAgent', js: 'desktopAgent', typ: '' }], 'any'),
   ErrorResponseMessagePayload: o([{ json: 'error', js: 'error', typ: r('ResponseErrorDetail') }], 'any'),
   AgentRequestMessage: o(
     [
@@ -4707,6 +4585,7 @@ const typeMap: any = {
     ],
     false
   ),
+  DesktopAgentIdentifier: o([{ json: 'desktopAgent', js: 'desktopAgent', typ: '' }], 'any'),
   ResponseErrorMessagePayload: o([{ json: 'error', js: 'error', typ: u(undefined, r('ResponseErrorDetail')) }], 'any'),
   BridgeRequestMessage: o(
     [
@@ -4951,7 +4830,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5003,7 +4881,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5118,7 +4995,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5160,7 +5036,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5255,7 +5130,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5291,7 +5165,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5372,7 +5245,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5408,7 +5280,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5483,7 +5354,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5533,7 +5403,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5898,7 +5767,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -5941,7 +5809,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -6037,7 +5904,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false
@@ -6058,7 +5924,6 @@ const typeMap: any = {
     [
       { json: 'requestUuid', js: 'requestUuid', typ: '' },
       { json: 'responseUuid', js: 'responseUuid', typ: '' },
-      { json: 'source', js: 'source', typ: r('DesktopAgentIdentifier') },
       { json: 'timestamp', js: 'timestamp', typ: Date },
     ],
     false


### PR DESCRIPTION
agent response messages don't need a source field as responses are always from the desktop agent itself AND the bridge is supposed to supply that information